### PR TITLE
Add request queue cooldown

### DIFF
--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -26,6 +26,13 @@ type Serving struct {
 	//
 	// This is the interval (in milliseconds) representing how often to do a fetch
 	DeploymentCachePollIntervalMS int `envconfig:"KEDA_HTTP_DEPLOYMENT_CACHE_POLLING_INTERVAL_MS" default:"250"`
+
+	// This indicates how long the interceptor should wait before setting the queue size to 0
+	// It's recommended to set this to a value to the same value as downstream gateway's timeout
+	RequestQueueCooldown time.Duration `envconfig:"KEDA_HTTP_REQUEST_QUEUE_COOLDOWN" default:"100s"`
+
+	// This is the interval at which the interceptor should enforce the cooldown
+	RequestQueueCooldownEnforcerInterval time.Duration `envconfig:"KEDA_HTTP_REQUEST_QUEUE_COOLDOWN_ENFORCER_INTERVAL" default:"1s"`
 }
 
 // Parse parses standard configs using envconfig and returns a pointer to the

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -28,11 +28,11 @@ type Serving struct {
 	DeploymentCachePollIntervalMS int `envconfig:"KEDA_HTTP_DEPLOYMENT_CACHE_POLLING_INTERVAL_MS" default:"250"`
 
 	// This indicates how long the interceptor should wait before setting the queue size to 0
-	// It's recommended to set this to a value to the same value as downstream gateway's timeout
-	RequestQueueCooldown time.Duration `envconfig:"KEDA_HTTP_REQUEST_QUEUE_COOLDOWN" default:"100s"`
+	// This prevents from KEDA asuming the service is not in use
+	RequestQueueCooldown time.Duration `envconfig:"KEDA_HTTP_REQUEST_QUEUE_COOLDOWN" default:"20s"`
 
-	// This is the interval at which the interceptor should enforce the cooldown
-	RequestQueueCooldownEnforcerInterval time.Duration `envconfig:"KEDA_HTTP_REQUEST_QUEUE_COOLDOWN_ENFORCER_INTERVAL" default:"1s"`
+	// This is the interval at which the interceptor will check if the queue size should be set to 0
+	RequestQueueCooldownEnforcerInterval time.Duration `envconfig:"KEDA_HTTP_REQUEST_QUEUE_COOLDOWN_ENFORCER_INTERVAL" default:"5s"`
 }
 
 // Parse parses standard configs using envconfig and returns a pointer to the

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	q := queue.NewMemory(servingCfg.RequestQueueCooldown)
 	routingTable := routing.NewTable()
-	go q.EnforceCooldown(servingCfg.RequestQueueCooldownEnforcerInterval)
+	go q.ProcessPostponedResizes(servingCfg.RequestQueueCooldownEnforcerInterval)
 
 	// Create the informer of ConfigMap resource,
 	// the resynchronization period of the informer should be not less than 1s,

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -83,8 +83,9 @@ func main() {
 
 	lggr.Info("Interceptor starting")
 
-	q := queue.NewMemory()
+	q := queue.NewMemory(servingCfg.RequestQueueCooldown)
 	routingTable := routing.NewTable()
+	go q.EnforceCooldown(servingCfg.RequestQueueCooldownEnforcerInterval)
 
 	// Create the informer of ConfigMap resource,
 	// the resynchronization period of the informer should be not less than 1s,

--- a/interceptor/middleware.go
+++ b/interceptor/middleware.go
@@ -62,7 +62,7 @@ func countMiddleware(
 		defer func() {
 			if q.Count(host) == 1 {
 				q.PostponeResize(host, time.Now().Add(q.PostponeDuration()))
-				lggr.Info("queue is empty and last request was less the cool down period, not decrementing", "host", host)
+				lggr.Info("postponing resize", "host", host)
 				return
 			}
 

--- a/interceptor/middleware.go
+++ b/interceptor/middleware.go
@@ -59,11 +59,10 @@ func countMiddleware(
 		if err := q.Resize(host, +1); err != nil {
 			log.Printf("Error incrementing queue for %q (%s)", r.RequestURI, err)
 		}
-		q.SetLastRequestTime(host, time.Now())
 		defer func() {
-			count, lastRequest := q.Status(host)
-			if count == 1 && time.Since(lastRequest) < q.GetCooldown() {
-				lggr.Info("queue is empty and last request was less the cool down period, not decrementing", "host", host, "count", count, "lastRequest", lastRequest)
+			if q.Count(host) == 1 {
+				q.PostponeResize(host, time.Now().Add(q.PostponeDuration()))
+				lggr.Info("queue is empty and last request was less the cool down period, not decrementing", "host", host)
 				return
 			}
 

--- a/pkg/queue/queue_fakes.go
+++ b/pkg/queue/queue_fakes.go
@@ -19,6 +19,26 @@ type FakeCounter struct {
 	ResizeTimeout time.Duration
 }
 
+// Count implements Counter.
+func (f *FakeCounter) Count(host string) int {
+	panic("unimplemented")
+}
+
+// PostponeDuration implements Counter.
+func (f *FakeCounter) PostponeDuration() time.Duration {
+	panic("unimplemented")
+}
+
+// PostponeResize implements Counter.
+func (f *FakeCounter) PostponeResize(host string, time time.Time) {
+	panic("unimplemented")
+}
+
+// ProcessPostponedResizes implements Counter.
+func (f *FakeCounter) ProcessPostponedResizes(sleep time.Duration) {
+	panic("unimplemented")
+}
+
 func NewFakeCounter() *FakeCounter {
 	return &FakeCounter{
 		mapMut:        new(sync.RWMutex),
@@ -71,6 +91,16 @@ var _ CountReader = &FakeCountReader{}
 type FakeCountReader struct {
 	current int
 	err     error
+}
+
+// Count implements CountReader.
+func (f *FakeCountReader) Count(host string) int {
+	panic("unimplemented")
+}
+
+// PostponeDuration implements CountReader.
+func (f *FakeCountReader) PostponeDuration() time.Duration {
+	panic("unimplemented")
 }
 
 func (f *FakeCountReader) Current() (*Counts, error) {

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -34,7 +34,7 @@ func TestCounts(t *testing.T) {
 		"host4": 809,
 	}
 
-	q := queue.NewMemory()
+	q := queue.NewMemory(time.Second)
 	for host, count := range counts {
 		r.NoError(q.Resize(host, count))
 	}
@@ -115,7 +115,7 @@ func TestFetchAndSaveCounts(t *testing.T) {
 		"host2": 234,
 		"host3": 345,
 	}
-	q := queue.NewMemory()
+	q := queue.NewMemory(time.Second)
 	for host, count := range counts.Counts {
 		r.NoError(q.Resize(host, count))
 	}
@@ -176,7 +176,7 @@ func TestFetchCounts(t *testing.T) {
 		"host2": 234,
 		"host3": 345,
 	}
-	q := queue.NewMemory()
+	q := queue.NewMemory(time.Second)
 	for host, count := range counts.Counts {
 		r.NoError(q.Resize(host, count))
 	}


### PR DESCRIPTION
This change is to prevent from `queue` size to be instantly set to zero on high efficient services resulting in premature scale downs 

https://github.com/wso2-enterprise/choreo/issues/27455