### PR TITLE
Removed FQDN suffix

### DIFF
--- a/interceptor/middleware.go
+++ b/interceptor/middleware.go
@@ -53,9 +53,9 @@ func getHost(r *http.Request) (string, error) {
 	// the destination namespace is not provided in the host header
 	// then the destination namespace is the same as the caller namespace
 	if strings.HasPrefix(remoteNs, "dp-") || destNs == "" {
-		host = fmt.Sprintf("%s.%s.svc.cluster.local", destService, remoteNs)
+		host = fmt.Sprintf("%s.%s", destService, remoteNs)
 	} else {
-		host = fmt.Sprintf("%s.%s.svc.cluster.local", destService, destNs)
+		host = fmt.Sprintf("%s.%s", destService, destNs)
 	}
 
 	return host, nil


### PR DESCRIPTION
This is needed to as per the original implementation https://github.com/wso2/choreo-keda-http-addon-fork/blob/bd80a53d765eb5721ac184bfdd64eb0ec7c1ca52/interceptor/middleware.go#L34