### PR TITLE
keda: fix keda interceptor admin server queue count issue

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -192,7 +192,10 @@ func (r *Memory) ProcessPostponedResizes(sleep time.Duration) {
 		// Perform modifications outside of the lock
 		r.mut.Lock()
 		for _, host := range hostsToModify {
-			r.concurrentMap[host] = 0
+			_, ok := r.concurrentMap[host]
+			if ok {
+				r.concurrentMap[host] = 0
+			}
 			delete(r.postponedResizes, host)
 		}
 		r.mut.Unlock()

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -144,7 +144,8 @@ func (r *Memory) Current() (*Counts, error) {
 	for key, concurrency := range r.concurrentMap {
 		rpsItem, ok := r.rpsMap[key]
 		if !ok {
-			return nil, fmt.Errorf(fmt.Sprintf("rps map doesn't contain the key '%s'", key))
+			r.logger.Error(fmt.Errorf(fmt.Sprintf("rps map doesn't contain the key '%s'", key)), "error getting rpsItem")
+			continue
 		}
 		cts.Counts[key] = Count{
 			Concurrency: concurrency,


### PR DESCRIPTION
This PR fixes the keda interceptor admin server queue count issue observed in Dev environment. We experienced a scenario where when scale to zero enabled we get a 504 Gateway timeout. 

Following logs were observed in the keda http add on interceptor during the incident.

```
2024-07-17T15:38:46Z	ERROR	runAdminServer.pkg.queue.AddCountsRoute	getting queue size	{"error": "rps map doesn't contain the key 'dp-production-usdp-8468-280847255/demo'"}
github.com/kedacore/http-add-on/pkg/queue.AddCountsRoute.newSizeHandler.func1
	github.com/kedacore/http-add-on/pkg/queue/queue_rpc.go:30
net/http.HandlerFunc.ServeHTTP
	net/http/server.go:2166
net/http.(*ServeMux).ServeHTTP
	net/http/server.go:2683
net/http.serverHandler.ServeHTTP
	net/http/server.go:3137
net/http.(*conn).serve
	net/http/server.go:2039
2024-07-17T15:38:47Z	ERROR	runAdminServer.pkg.queue.AddCountsRoute	getting queue size	{"error": "rps map doesn't contain the key 'dp-production-usdp-8468-280847255/demo'"}
github.com/kedacore/http-add-on/pkg/queue.AddCountsRoute.newSizeHandler.func1
	github.com/kedacore/http-add-on/pkg/queue/queue_rpc.go:30
net/http.HandlerFunc.ServeHTTP
	net/http/server.go:2166
net/http.(*ServeMux).ServeHTTP
	net/http/server.go:2683
net/http.serverHandler.ServeHTTP
	net/http/server.go:3137
net/http.(*conn).serve
	net/http/server.go:2039
``` 

Following logs were observed in the keda http add on scaler during the incident.

```
{"level":"error","ts":"2024-07-18T03:09:55Z","msg":"getting request counts","error":"decoding response from the interceptor at http://10.42.0.7:9090/queue: invalid character 'e' looking for beginning of value","stacktrace":"main.(*queuePinger).fetchAndSaveCounts\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:144\nmain.(*queuePinger).start\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:106\nmain.main.func3\n\tgithub.com/kedacore/http-add-on/scaler/main.go:115\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.7.0/errgroup/errgroup.go:78"}
{"level":"error","ts":"2024-07-18T03:09:55Z","logger":"scaler.queuePinger.start","msg":"getting request counts","error":"decoding response from the interceptor at http://10.42.0.7:9090/queue: invalid character 'e' looking for beginning of value","stacktrace":"main.(*queuePinger).start\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:108\nmain.main.func3\n\tgithub.com/kedacore/http-add-on/scaler/main.go:115\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.7.0/errgroup/errgroup.go:78"}
{"level":"error","ts":"2024-07-18T03:09:56Z","logger":"queuePinger.requestCounts","msg":"getting queue counts from interceptor","interceptorAddress":"http://10.42.0.7:9090","error":"decoding response from the interceptor at http://10.42.0.7:9090/queue: invalid character 'e' looking for beginning of value","stacktrace":"main.fetchCounts.func1\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:208\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.7.0/errgroup/errgroup.go:78"}
{"level":"error","ts":"2024-07-18T03:09:56Z","logger":"queuePinger.requestCounts","msg":"fetching all counts failed","error":"decoding response from the interceptor at http://10.42.0.7:9090/queue: invalid character 'e' looking for beginning of value","stacktrace":"main.fetchCounts\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:237\nmain.(*queuePinger).fetchAndSaveCounts\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:135\nmain.(*queuePinger).start\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:106\nmain.main.func3\n\tgithub.com/kedacore/http-add-on/scaler/main.go:115\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.7.0/errgroup/errgroup.go:78"}
{"level":"error","ts":"2024-07-18T03:09:56Z","msg":"getting request counts","error":"decoding response from the interceptor at http://10.42.0.7:9090/queue: invalid character 'e' looking for beginning of value","stacktrace":"main.(*queuePinger).fetchAndSaveCounts\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:144\nmain.(*queuePinger).start\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:106\nmain.main.func3\n\tgithub.com/kedacore/http-add-on/scaler/main.go:115\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.7.0/errgroup/errgroup.go:78"}
{"level":"error","ts":"2024-07-18T03:09:56Z","logger":"scaler.queuePinger.start","msg":"getting request counts","error":"decoding response from the interceptor at http://10.42.0.7:9090/queue: invalid character 'e' looking for beginning of value","stacktrace":"main.(*queuePinger).start\n\tgithub.com/kedacore/http-add-on/scaler/queue_pinger.go:108\nmain.main.func3\n\tgithub.com/kedacore/http-add-on/scaler/main.go:115\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\tgolang.org/x/sync@v0.7.0/errgroup/errgroup.go:78"}
```

keda interceptor has an admin server and the keda scaler uses that admin server to fetch queue counts. In this scenario according to the logs, keda admin server is unable to serve the queue counts and hence the keda scaler is unable to provide the required scaling info to the keda http add on operator. So the workloads are not getting scaled and the gateway timeout triggers.

The root cause for this behaviour occurs due to an edge case with the latest v0.8.0 release and our postpone queue mechanism.

```
func (r *Memory) Current() (*Counts, error) {
	r.mut.RLock()
	defer r.mut.RUnlock()
	cts := NewCounts()
	for key, concurrency := range r.concurrentMap {
		rpsItem, ok := r.rpsMap[key]
		if !ok {
			return nil, fmt.Errorf(fmt.Sprintf("rps map doesn't contain the key '%s'", key))
		}
		cts.Counts[key] = Count{
			Concurrency: concurrency,
			RPS:         rpsItem.WindowAverage(time.Now()),
		}
	}
	return cts, nil
}
```

keda interceptor admin sever uses the following function to server queue counts requests and it has a validation to check the existence of keys in both concurrentMap and rpsMap which is introduced with the latest release version. In the incident observed in due, it says `rps map doesn't contain the key` which conveys that the concurrentMap entry exists but the rpsMapEntry doesn't exist. 

With the latest implementation, interceptor watches for HTTPScaledObjects using a shared informer and deletes the entries if the HTTPScaledObject is deleted or renamed. Our postpone queue implementation can conflict with the above as we update the concurrentMap with value 0 for a given key. If the keys is already deleted, we add an inconsistence entry and it results in the above behaviour. This can be fixed by checking the existence of the key in postpone queue implementation. 

related to https://github.com/wso2-enterprise/choreo/issues/29181