### PR TITLE
keda: fix static handler error

### DIFF
--- a/interceptor/middleware/routing.go
+++ b/interceptor/middleware/routing.go
@@ -39,7 +39,7 @@ func (rm *Routing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = util.RequestWithLoggerWithName(r, "RoutingMiddleware")
 	host, err := getHost(r)
 	if err != nil {
-		sh := handler.NewStatic(http.StatusNotFound, nil)
+		sh := handler.NewStatic(http.StatusNotFound, err)
 		sh.ServeHTTP(w, r)
 	}
 	r.Host = host


### PR DESCRIPTION
This PR fixes the issue of the static handler not logging the error.