### PR TITLE
keda: add retry for keda interceptor reverse DNS check

### DIFF
--- a/interceptor/middleware/utils.go
+++ b/interceptor/middleware/utils.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func getHost(r *http.Request) (string, error) {
@@ -27,10 +28,22 @@ func getHost(r *http.Request) (string, error) {
 	}
 
 	// ReverseDNS lookup on the remote IP
-	names, err := net.LookupAddr(remoteIP)
+	var names []string
+	var err error
+	maxRetries := 3
+	retryDelay := 3 * time.Second
+
+	for i := 0; i < maxRetries; i++ {
+		names, err = net.LookupAddr(remoteIP)
+		if err == nil && len(names) > 0 {
+			break
+		}
+		time.Sleep(retryDelay)
+	}
 	if err != nil {
 		return "", fmt.Errorf("error looking up address %q: %s", remoteIP, err)
 	}
+
 	if len(names) == 0 {
 		return "", fmt.Errorf("no names found for address %q", remoteIP)
 	}


### PR DESCRIPTION
Add a retry for the reverse DNS check in the keda interceptor. This is related to the issue https://github.com/wso2-enterprise/choreo/issues/29851
