### PR TITLE
Revert port routing from URL and remove unwanted logs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,8 @@
+# ignore keda upstream vulnerabilities. fixed versions available but it requires a golang version bump.
+
+# GH issue to track: https://github.com/wso2-enterprise/choreo/issues/33073
+
+CVE-2024-45338
+CVE-2024-24790
+CVE-2024-24788
+CVE-2024-34156

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -46,15 +47,12 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httpso := util.HTTPSOFromContext(ctx)
-	logger.Info("Upstream", "httpso", httpso.Spec.ScaleTargetRef.Service, "host", r.Host, "RequestURI", r.RequestURI, "URL", r.URL.String(), "port", r.URL.Port())
-	if r.URL.Port() != "" {
+	if i := strings.Index(r.Host, ":"); i != -1 {
 		// if the host header contains port, route to ( routingTarget.Service:port)
-		targetPort := r.URL.Port()
+		targetPort := r.Host[i+1:]
 		targetHost := fmt.Sprintf("http://%s.%s:%s", httpso.Spec.ScaleTargetRef.Service, httpso.GetNamespace(), targetPort)
-		logger.Info("Upstream", "targetPort", targetPort, "targetHost", targetHost)
 		var err error
 		if stream, err = url.Parse(targetHost); err != nil {
-			logger.Error(err, "forwarding failed")
 			w.WriteHeader(500)
 			if _, err := w.Write([]byte(fmt.Sprintf("error parsing host:port: %s to URL", targetHost))); err != nil {
 				logger.Error(err, "could not write error response to client")
@@ -62,7 +60,6 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	logger.Info("Upstream", "stream", stream.String())
 
 	proxy := httputil.NewSingleHostReverseProxy(stream)
 	superDirector := proxy.Director

--- a/interceptor/middleware/routing.go
+++ b/interceptor/middleware/routing.go
@@ -45,17 +45,13 @@ func (rm *Routing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = util.RequestWithLoggerWithName(r, "RoutingMiddleware")
 	ctx := r.Context()
 	logger := util.LoggerFromContext(ctx)
-	hostHeader := r.Header.Get("Host")
-	logger.Info("Routing", "received host", r.Host, "url", r.URL.String(), "port", r.URL.Port(), "RequestURI", r.RequestURI, "hostHeader", hostHeader)
 	host, err := getHost(r, rm.reverseDNSRetry, rm.reverseDNSRetryInterval)
-	logger.Info("Routing", "host", r.Host, "modifiedHost", host)
 	if err != nil {
 		sh := handler.NewStatic(http.StatusNotFound, err)
 		sh.ServeHTTP(w, r)
 	}
 	r.Host = host
 	httpso := rm.routingTable.Route(r)
-	logger.Info("Routing", "httpso", httpso)
 	if httpso == nil {
 		if rm.isProbe(r) {
 			rm.probeHandler.ServeHTTP(w, r)

--- a/interceptor/middleware/utils.go
+++ b/interceptor/middleware/utils.go
@@ -23,10 +23,11 @@ func getHost(r *http.Request, reverseDNSRetry int, reverseDNSRetryInternal time.
 		return "", fmt.Errorf("host not found")
 	}
 	// removing port if exists
+	hostPort := ""
 	if i := strings.Index(host, ":"); i != -1 {
 		host = host[:i]
+		hostPort = host[i:]
 	}
-	hostPort := r.URL.Port()
 
 	// ReverseDNS lookup on the remote IP
 	var names []string


### PR DESCRIPTION
This PR reverts the port based routing based on URL in port which was added in https://github.com/wso2/choreo-keda-http-addon-fork/pull/49 and debug logs added in https://github.com/wso2/choreo-keda-http-addon-fork/pull/51, https://github.com/wso2/choreo-keda-http-addon-fork/pull/50, https://github.com/wso2/choreo-keda-http-addon-fork/pull/47.