### PR TITLE
[Release/v0.8.0] Handle rpsMap nil scenario by providing a default value

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,7 +1,6 @@
 package queue
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -144,7 +143,6 @@ func (r *Memory) Current() (*Counts, error) {
 	for key, concurrency := range r.concurrentMap {
 		rpsItem, ok := r.rpsMap[key]
 		if !ok {
-			r.logger.Error(fmt.Errorf(fmt.Sprintf("rps map doesn't contain the key '%s'", key)), "error getting rpsItem")
 			continue
 		}
 		cts.Counts[key] = Count{
@@ -188,10 +186,7 @@ func (r *Memory) ProcessPostponedResizes(sleep time.Duration) {
 				}
 			}
 		}
-		r.mut.Unlock()
 
-		// Perform modifications outside of the lock
-		r.mut.Lock()
 		for _, host := range hostsToModify {
 			_, ok := r.concurrentMap[host]
 			if ok {

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -143,11 +143,15 @@ func (r *Memory) Current() (*Counts, error) {
 	for key, concurrency := range r.concurrentMap {
 		rpsItem, ok := r.rpsMap[key]
 		if !ok {
-			continue
-		}
-		cts.Counts[key] = Count{
-			Concurrency: concurrency,
-			RPS:         rpsItem.WindowAverage(time.Now()),
+			cts.Counts[key] = Count{
+				Concurrency: concurrency,
+				RPS:         0,
+			}
+		} else {
+			cts.Counts[key] = Count{
+				Concurrency: concurrency,
+				RPS:         rpsItem.WindowAverage(time.Now()),
+			}
 		}
 	}
 	return cts, nil


### PR DESCRIPTION
This PR handles the rpsMap nil scenario of the keda intereceptor rpsMap by returning the default value of 0. This is done in relation to the ongoing incident of high log volume in keda namespace in https://github.com/wso2-enterprise/choreo/issues/33273
