### PR TITLE
Implement HTTP hijacker to support websocket connections

### DIFF
--- a/interceptor/middleware/responsewriter.go
+++ b/interceptor/middleware/responsewriter.go
@@ -1,6 +1,9 @@
 package middleware
 
 import (
+	"bufio"
+	"errors"
+	"net"
 	"net/http"
 )
 
@@ -45,4 +48,12 @@ func (rw *responseWriter) WriteHeader(statusCode int) {
 	rw.downstreamResponseWriter.WriteHeader(statusCode)
 
 	rw.statusCode = statusCode
+}
+
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := rw.downstreamResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+
+	return nil, nil, errors.New("http.Hijacker not implemented")
 }


### PR DESCRIPTION
This PR implements the HTTP hijacker to support websocket connections (https://github.com/kedacore/http-add-on/pull/835). HTTP Hijacker will take perform the connection upgrade and handle the TCP connection until the connection is closed.

Fixes https://github.com/wso2-enterprise/choreo/issues/35733

Related to https://github.com/wso2-enterprise/choreo-product-management/issues/657