### PR TITLE
Increase channel buffer to 1000 in legacy routing mode

### DIFF
--- a/pkg/util/signaler.go
+++ b/pkg/util/signaler.go
@@ -12,7 +12,7 @@ type Signaler interface {
 type signaler chan struct{}
 
 func NewSignaler() Signaler {
-	return make(signaler, 1)
+	return make(signaler, 1000)
 }
 
 var _ Signaler = (*signaler)(nil)


### PR DESCRIPTION
This PR increase the channel buffer size to 1000 for legacy routing mode.

Related to https://github.com/wso2-enterprise/choreo/issues/36986
