### PR TITLE
Preserve X-headers during request forwarding

### DIFF
--- a/interceptor/request_forwarder.go
+++ b/interceptor/request_forwarder.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -23,11 +24,26 @@ func forwardRequest(
 	proxy := httputil.NewSingleHostReverseProxy(fwdSvcURL)
 	proxy.Transport = roundTripper
 	proxy.Director = func(req *http.Request) {
+		// Capture all X-* headers from the original request before
+		// modifying the outgoing request, so they are preserved
+		// through the proxy and not lost or overwritten.
+		xHeaders := make(http.Header)
+		for key, values := range r.Header {
+			if strings.HasPrefix(strings.ToUpper(key), "X-") {
+				xHeaders[key] = values
+			}
+		}
 		req.URL = fwdSvcURL
 		req.Host = fwdSvcURL.Host
 		req.URL.Path = r.URL.Path
 		req.URL.RawQuery = r.URL.RawQuery
 		req.Header.Del("X-Forwarded-For")
+		// Restore all original X-* headers (except X-Forwarded-For)
+		for key, values := range xHeaders {
+			if !strings.EqualFold(key, "X-Forwarded-For") {
+				req.Header[key] = values
+			}
+		}
 	}
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
 		w.WriteHeader(502)

--- a/interceptor/request_forwarder_test.go
+++ b/interceptor/request_forwarder_test.go
@@ -288,3 +288,51 @@ func TestForwardRequestRedirectAndHeaders(t *testing.T) {
 	r.Equal("somethingcustom", res.Header().Get("X-Custom-Header"))
 	r.Equal("Hello from srv", res.Body.String())
 }
+
+func TestForwardRequestPreservesXHeaders(t *testing.T) {
+	r := require.New(t)
+	expectedHeaders := map[string]string{
+		"X-Correlation-Id": "test-correlation-123",
+		"X-Request-Id":     "req-456",
+		"X-Trace-Id":       "trace-789",
+	}
+
+	receivedHeaders := make(map[string]string)
+	srv, srvURL, err := kedanet.StartTestServer(
+		kedanet.NewTestHTTPHandlerWrapper(
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				for key := range expectedHeaders {
+					receivedHeaders[key] = req.Header.Get(key)
+				}
+				w.WriteHeader(200)
+				_, err := w.Write([]byte("ok"))
+				r.NoError(err)
+			}),
+		),
+	)
+	r.NoError(err)
+	defer srv.Close()
+
+	timeouts := defaultTimeouts()
+	timeouts.Connect = 10 * time.Millisecond
+	timeouts.ResponseHeader = 10 * time.Millisecond
+	backoff := timeouts.Backoff(2, 2, 1)
+	dialCtxFunc := retryDialContextFunc(timeouts, backoff)
+	res, req, err := reqAndRes("/testfwd")
+	r.NoError(err)
+	for key, val := range expectedHeaders {
+		req.Header.Set(key, val)
+	}
+	forwardRequest(
+		logr.Discard(),
+		res,
+		req,
+		newRoundTripper(dialCtxFunc, timeouts.ResponseHeader),
+		srvURL,
+		2,
+	)
+	r.Equal(200, res.Code)
+	for key, expected := range expectedHeaders {
+		r.Equal(expected, receivedHeaders[key], "%s header was not preserved", key)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Preserve X-headers during request forwarding and add a test case to verify their preservation.

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header preservation during request forwarding to maintain custom headers across proxy calls, ensuring request tracking information is retained through the proxy layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->